### PR TITLE
remove fa-icon instruction generating invisible divs 

### DIFF
--- a/_posts/1005-01-01-mapa.md
+++ b/_posts/1005-01-01-mapa.md
@@ -2,7 +2,6 @@
 title: "Mapas"
 bg: white
 color: black
-fa-icon: toggle-on
 lang: es
 ---
 

--- a/_posts/1007-01-01-faq.md
+++ b/_posts/1007-01-01-faq.md
@@ -2,7 +2,6 @@
 title: "Preguntas Frecuentes"
 bg: white
 color: black
-fa-icon: check-square-o
 ---
 
 # Preguntas Frecuentes


### PR DESCRIPTION
Si el markdown especifica un fa-icon se generan unas divisiones invisibles (sin fa-icon) que rompen el diseño en móvil en las secciones de Mapas de Ayuda y FAQs.

closes #56 