### PR TITLE
Archivo con proyectos al rededor del sismo

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,17 +58,8 @@ La conversación y coordinación de las tareas las estamos llevando en el Slack 
 
 ## Proyectos de la comunidad
 
-| Proyecto | Descripción | Repositorio | Slack | Stack |
-| :--- | :--- | :--- | :--- | :--- |
-| Acopio API | API para centros de acopio | https://github.com/Skycatch/acopio-api | `#sismomx-acopio-api` | Javascript, Hapi | 
-| Ayuda México | N/A | https://github.com/erikcaffrey/AyudaMexico | `#equipo-humanitario` | Java | 
-| Ban Fake News | N/A | https://github.com/RZEROSTERN/banfakenews | `#sismomx-fakenews` | PHP, Yii | 
-| Cómo Ayudar MX | N/A | https://github.com/eldelentes/comoayudarmx | `#sismomx-camx` | HTML5, CSS | 
-| Información Valiosa de Twitter | Filtra información valiosa relacionada al terremot | https://github.com/Garyi/Filtro-Informaci-n-Valiosa-Terremoto-Twitter | `#equipo-humanitario` | Python | 
-| Mapeo Colaborativo | Herramienta para el reporte ciudadano  | https://github.com/miguelsalazar/mapeo_colaborativo | `#equipo-humanitario` | Javascript, Express, Socket.io | 
-| Quake Relief CDMX | Encontrar las necesidades más prioritarias por zona para enviar ayuda y notificar | https://github.com/civica-digital/quake-relief-cdmx | `#sismomx-realtime` | Ruby on Rails 5 | 
-| SMS Alerts | Send SMS alerts for the earthquake in mexico  | https://github.com/denialtorres/SMS-ALERTS | `#equipo-humanitario` | Ruby on Rails 4.2 | 
-| Sitio web | Sitio web con la recopilación de recursos  | https://github.com/CodeandoMexico/terremoto-cdmx | `#sismomx-website` | Jekyll, HTML, CSS, Javsscript | 
+[Ve los proyectos que decenas de hackers cívicos están desarrollando y contribuye o agrega un recurso](proyectos.md)
+
 
 
 ## Sitio web <a name="sitioweb"></a>

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ La conversación y coordinación de las tareas las estamos llevando en el Slack 
 
 ## Proyectos de la comunidad
 
-[Ve los proyectos que decenas de hackers cívicos están desarrollando y contribuye o agrega un recurso](proyectos.md)
+[Ve los proyectos que otras personas y organizaciónes están realizando, algunos necesitan ayuda](proyectos.md)
 
 
 

--- a/proyectos.md
+++ b/proyectos.md
@@ -5,7 +5,7 @@ Debido a la creciente cantidad de esfuerzos al rededor del sismo, se considera i
 * No duplicar esfuerzos, sumarlos
 * Contribuír con habilidades técnicas y no técnicas
 * Difundir en redes sociales y personas que puedan necesitar de estas soluciones
-* Crear una lista de posibles nuevas herramientas que sean necesarias a través de [Abrir issues][new-issue]
+* Crear una lista de posibles nuevas herramientas que sean necesarias a través de Abrir Issues
 
 
 ## Guías sobre cómo ayudar (Si no fuiste afectado y quieres ayudar)

--- a/proyectos.md
+++ b/proyectos.md
@@ -53,6 +53,7 @@ Nombre del recurso| Descripción | URL     |  Guía para contribuír | Contacto 
 
 ### Contribuye
 
-1. Agrega un recurso haciendo un fork y mandando un pull-request (Si no sabes como hacerlo da click aquí y comparte la informasión en un [Issue][new-issue])
+1. Agrega un recurso haciendo un fork y mandando un pull-request 
+    1.1 Si no sabes como hacerlo da click aquí y comparte la informasión en un [Issue][new-issue]
 2. Agrega una categoría que creas que hace falta
 3. Si crees que hay algo que podemos hacer para mejorar esta lista, los pull-request son bienvenidos

--- a/proyectos.md
+++ b/proyectos.md
@@ -53,7 +53,6 @@ Nombre del recurso| Descripción | URL     |  Guía para contribuír | Contacto 
 
 ### Contribuye
 
-1. Agrega un recurso haciendo un fork y mandando un pull-request 
-    1.1 Si no sabes como hacerlo da click aquí y comparte la informasión en un [Issue][new-issue]
+1. Agrega un recurso haciendo un fork y mandando un pull-request. Si no sabes como hacerlo da click aquí y comparte la informasión en un [Issue](new-issue)
 2. Agrega una categoría que creas que hace falta
 3. Si crees que hay algo que podemos hacer para mejorar esta lista, los pull-request son bienvenidos

--- a/proyectos.md
+++ b/proyectos.md
@@ -53,6 +53,6 @@ Nombre del recurso| Descripción | URL     |  Guía para contribuír | Contacto 
 
 ### Contribuye
 
-1. Agrega un recurso haciendo un fork y mandando un pull-request. Si no sabes como hacerlo da click aquí y comparte la informasión en un [Issue](new-issue)
+1. Agrega un recurso haciendo un fork y mandando un pull-request. Si no sabes como hacerlo da click aquí y comparte la informasión en un Issue
 2. Agrega una categoría que creas que hace falta
 3. Si crees que hay algo que podemos hacer para mejorar esta lista, los pull-request son bienvenidos

--- a/proyectos.md
+++ b/proyectos.md
@@ -1,0 +1,58 @@
+# Plataformas y esfuerzos tecnológicos en respuesta al sismo
+
+Debido a la creciente cantidad de esfuerzos al rededor del sismo, se considera importante crear esta lista para:
+
+* No duplicar esfuerzos, sumarlos
+* Contribuír con habilidades técnicas y no técnicas
+* Difundir en redes sociales y personas que puedan necesitar de estas soluciones
+* Crear una lista de posibles nuevas herramientas que sean necesarias a través de [Abrir issues][new-issue]
+
+
+## Guías sobre cómo ayudar (Si no fuiste afectado y quieres ayudar)
+
+Nombre del recurso| Descripción | URL     |  Guía para contribuír | Contacto | Stack | Status 
+------------      | ----------- | ------  | --------------------  | -------- | ----- | ------ 
+comoayudar.mx  | Encuentra una forma en la que puedas ayudar a los afectados | [http://comoayudar.mx/](http://comoayudar.mx/) | [Github](https://github.com/eldelentes/comoayudarmx) | nA | Ruby on Rails | en desarrollo 
+Ban Fake News | N/A | nA | [https://github.com/RZEROSTERN/banfakenews](https://github.com/RZEROSTERN/banfakenews) | [Slack -> #sismomx-fakenews](http://slack.codeandomexico.org/) | PHP, Yii |  En funcionamiento 
+
+
+## Difusión de información importante (Qué hacer si fuiste afectado)
+
+Nombre del recurso| Descripción | URL     |  Guía para contribuír | Contacto | Stack | Status |
+------------      | ----------- | ------  | --------------------  | -------- | ----- | ------ |
+sismomexico.org| Sitio web con la recopilación de recursos  | [http://www.sismomexico.org](http://www.sismomexico.org) | [Github](https://github.com/CodeandoMexico/terremoto-cdmx) | [Slack -> #sismomx-website](http://slack.codeandomexico.org/) | Jekyll, HTML, CSS, Javsscript  | Abierto a contribuciones |
+
+
+## Mapas
+Nombre del recurso| Descripción | URL     |  Guía para contribuír | Contacto | Stack | Status |
+------------      | ----------- | ------  | --------------------  | -------- | ----- | ------ 
+| Mapeo Colaborativo | Herramienta para el reporte ciudadano | nA | [https://github.com/miguelsalazar/mapeo_colaborativo](https://github.com/miguelsalazar/mapeo_colaborativo) | [Slack -> ##equipo-humanitario](http://slack.codeandomexico.org/) | Javascript, Express, Socket.io | En desarrollo |
+
+## Apps
+Nombre del recurso| Descripción | URL     |  Guía para contribuír | Contacto | Stack | Status |
+------------      | ----------- | ------  | --------------------  | -------- | ----- | ------
+| Ayuda México | N/A |nA | [https://github.com/erikcaffrey/AyudaMexico](ttps://github.com/erikcaffrey/AyudaMexico) | [Slack -> #equipo-humanitario](http://slack.codeandomexico.org/) | Java |  | 
+
+## APIs
+Nombre del recurso| Descripción | URL     |  Guía para contribuír | Contacto | Stack | Status |
+------------      | ----------- | ------  | --------------------  | -------- | ----- | ------ |
+| Acopio API | API para centros de acopio | nA |  [https://github.com/Skycatch/acopio-api](https://github.com/Skycatch/acopio-api) | [Slack -> #sismomx-acopio-api](http://slack.codeandomexico.org/) | Javascript, Hapi | ? |
+
+## Bots & Web Services
+
+Nombre del recurso| Descripción | URL     |  Guía para contribuír | Contacto | Stack | Status |
+------------      | ----------- | ------  | --------------------  | -------- | ----- | ------ |
+|Tweetbot  desaparecidos, sismo 2017 | n/a | nA | [Github](https://github.com/regenhans/earthquake-bot)| [Slack](http://slack.codeandomexico.org/)| NodeJS | abierto a contribuciones |
+|SMS Alerts | Send SMS alerts for the earthquake in mexico | nA |  [https://github.com/denialtorres/SMS-ALERTS](https://github.com/denialtorres/SMS-ALERTS]) | [Slack -> #equipo-humanitario](http://slack.codeandomexico.org/) | Ruby on Rails 4.2 | ? |
+| Información Valiosa de Twitter | Filtra información valiosa relacionada al terremot | nA |[https://github.com/Garyi/Filtro-Informaci-n-Valiosa-Terremoto-Twitter](https://github.com/Garyi/Filtro-Informaci-n-Valiosa-Terremoto-Twitter) | [Slack -> #equipo-humanitario](http://slack.codeandomexico.org/)  | Python | |
+| Quake Relief CDMX | Encontrar las necesidades más prioritarias por zona para enviar ayuda y notificar | nA | [https://github.com/civica-digital/quake-relief-cdmx](https://github.com/civica-digital/quake-relief-cdmx) | [Slack -> #sismomx-realtime](http://slack.codeandomexico.org/) | Ruby on Rails 5 | |
+
+
+
+
+
+### Contribuye
+
+1. Agrega un recurso haciendo un fork y mandando un pull-request (Si no sabes como hacerlo da click aquí y comparte la informasión en un [Issue][new-issue])
+2. Agrega una categoría que creas que hace falta
+3. Si crees que hay algo que podemos hacer para mejorar esta lista, los pull-request son bienvenidos


### PR DESCRIPTION
Debido a la creciente cantidad de esfuerzos al rededor del sismo, se considera importante crear esta lista para:

* No duplicar esfuerzos, sumarlos
* Contribuír con habilidades técnicas y no técnicas
* Difundir en redes sociales y personas que puedan necesitar de estas soluciones
* Crear una lista de posibles nuevas herramientas que sean necesarias a través de Abrir Issues

Se modificó readme para dirigir a este archivo en la sección de proyectos. 
