### PR TITLE
Remover mapa de Ubicacion de areas criticas

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,6 @@ La conversación y coordinación de las tareas las estamos llevando en el Slack 
 ### Mapas
 
 * Súmate al [mapeo de centros de acopio y áreas críticas de Morelos](https://www.google.com/maps/d/viewer?mid=1UsEmeSqMGW1fIgbzPN4jKY027WA&ll=18.890876248235475%2C-98.85296411690791&z=10). Escribe a @borntobealai en Telegram/Twitter para solicitar acceso de edición. [Guía para mapear](https://docs.google.com/document/d/1mbFmsjVBRCEVPbcIrYZY9sk6rMLptLhe1LQ6r0o0HsI/edit)
-* Súmate al [mapeo de centros de acopio y áreas críticas de CDMX](https://www.google.com/maps/d/viewer?mid=1PwJrCIjz5PNfKAFrY-EX-iEkWH8). Escribe a @ricardoe en Telegram/Twitter o @efectotequila para solicitar acceso de edición. [Guía para mapear](https://docs.google.com/document/d/1eYf-JL09Yta54gYqaBIKB4HDH7rM2iVbIHRJ_zES1DI/edit?usp=sharing)
-
 
 ## Proyectos de la comunidad
 

--- a/_posts/1005-01-01-mapa.md
+++ b/_posts/1005-01-01-mapa.md
@@ -13,8 +13,4 @@ lang: es
 	<iframe src="https://www.google.com/maps/d/u/0/embed?mid=13B_gbt3e5RWk_6xQoQ15xxhGOFs&ll=19.373256300000023%2C-99.13833979999998&z=11&hootPostID=1f18a5617f5da88fa1f7bff84bf31a46" width="100%" height="480"></iframe>
 </div>
 
-<div class="icontain">
-	<iframe src="https://www.google.com/maps/d/u/0/embed?hl=en&mid=1PwJrCIjz5PNfKAFrY-EX-iEkWH8&ll=19.372169291390605%2C-99.16998963041652&z=14" width="100%" height="480"></iframe>
-</div>
-
 Ayuda al equipo de OpenStreetMap a mapear esta zona: [http://tasks.hotosm.org/project/3597](http://tasks.hotosm.org/project/3597){:target="_blank"}


### PR DESCRIPTION
Este mapa ya se congelo para dar paso al oficial de google u otro que genere #sismomx-mapas