### PR TITLE
Remover dependencia en Roboto desde el index.html

### DIFF
--- a/_includes/css/atoms.css
+++ b/_includes/css/atoms.css
@@ -5,7 +5,7 @@
   display: -o-flex;
   display: flex;
   align-items: center;
-  font-family: 'Roboto Mono', monospace;
+  font-family: 'Helvetica', 'Arial', sans-serif;
 }
 
 #intro {

--- a/assets/_scss/_variables.scss
+++ b/assets/_scss/_variables.scss
@@ -6,7 +6,8 @@ $smx-pink-color: #F3476D;
 $smx-dark-black-color: #2E2E2E;
 $smx-black-color: #000;
 
-$smx-font-family: 'Roboto Mono', sans-serif;
+
+$smx-font-family: 'Helvetica', 'Arial', sans-serif;
 $smx-font-bolder: 700;
 $smx-font-regular: 400;
 $smx-font-lighter: 300;

--- a/index.html
+++ b/index.html
@@ -9,7 +9,6 @@
     <meta name="keywords" content="{{ site.keywords }}">
     <meta name="description" content="{{ site.description }}">
     <link rel="stylesheet" href="{{ "main.css" | prepend: site.assets.css }}">
-    <link href="https://fonts.googleapis.com/css?family=Roboto|Roboto+Mono" rel="stylesheet">
     {% if site.favicon %}<link rel="shortcut icon" href="{{ site.favicon }}" type="image/x-icon">{% endif %}
     {% if site.touch_icon %}<link rel="apple-touch-icon" href="{{ site.touch_icon }}">{% endif %}
     {% if site.google_analytics and jekyll.environment == 'production' %}


### PR DESCRIPTION
**TODO:** Remover la dependencia de Roboto desde los mapas.

Los dos mapas embebidos en el sitio dependen de Roboto también. Pero se puede hacer lazy loading de ellos y el `index.html` cargaría más rápido,