### PR TITLE
Fix URLs in SEO related meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,18 +3,18 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta charset="UTF-8" />
+    <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ site.title }}</title>
     <meta name="keywords" content="{{ site.keywords }}">
     <meta name="description" content="{{ site.description }}">
     <meta name="format-detection" content="telephone=no">
-    <meta property="og:title" content="{{site.tittle}}" />
-    <meta property="og:locale" content="es_MX" />
-    <meta property="og:description" content="{{site.description}} " />
-    <link rel="canonical" href="http://sismomexico.org" />
-    <meta property="og:url" content="http://sismomexico.org" />
-    <meta property="og:site_name" content="Jekyll SEO Tag" />
+    <meta property="og:title" content="{{ site.tittle }}">
+    <meta property="og:locale" content="es_MX">
+    <meta property="og:description" content="{{ site.description }}">
+    <link rel="canonical" href="https://sismomexico.org">
+    <meta property="og:url" content="https://sismomexico.org">
+    <meta property="og:site_name" content="Jekyll SEO Tag">
     <meta name="twitter:card" content="summary">
     {% if page.title %}<meta name="twitter:title" content="{{ page.title }}">{% else %}
     <meta name="twitter:title" content="{{ site.title }}">{% endif %}


### PR DESCRIPTION
Fix URLs in SEO related `<meta>` tags in order to make them consistent with the ones contained in `sitemap.xml`. This is part of SEO improvements (#93)