### PR TITLE
Docker for local development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM ruby:2.2.3
+
+# Install essential Linux packages
+RUN apt-get update -qq && apt-get install 
+
+# Define where our application will live inside the image
+ENV ROOT_PROJECT /var/www/terremoto-cdmx
+
+# Create application home. App server will need the pids dir so just create everything in one shot
+
+
+# Set our working directory inside the image
+WORKDIR $ROOT_PROJECT
+
+# Use the Gemfiles as Docker cache markers. Always bundle before copying app src.
+# (the src likely changed and we don't want to invalidate Docker's cache too early)
+# http://ilikestuffblog.com/2014/01/06/how-to-skip-bundle-install-when-deploying-a-rails-app-to-docker/
+COPY Gemfile Gemfile
+
+COPY Gemfile.lock Gemfile.lock
+
+# Prevent bundler warnings; ensure that the bundler version executed is >= that which created Gemfile.lock
+RUN gem install bundler
+
+# Finish establishing our Ruby enviornment
+RUN bundle install
+
+# Copy the Rails application into place
+COPY . .
+
+CMD jekyll serve

--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ $ bundle install
 $ jekyll serve
 ```
 
+#### Intrucciones para desarrollo local con docker
+
+```
+$ docker build -t terremoto-cdmx .
+$ docker run -p 4000:4000 terrmoto-cdmx
+```
+
 El sistema estará disponible en http://127.0.0.1:4000/
 
 ## Licencia


### PR DESCRIPTION
Se dockeriza el sitio para el facilitar el desarrollo local en ambientes que no sean Linux o OSX. Se dejan las instrucciones en el README para construir y correr la imagen.