### PR TITLE
Comentar Footer Link

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -9,8 +9,8 @@
     </div>
     <div class="one-third column">
       <ul class="footer_links">
-        <li><a href="#section-mapa">Mapas de Ayuda</a></li>
         <!--
+        <li><a href="#section-mapa">Mapas de Ayuda</a></li>
         <li>Agradecimientos</li>
         <li>Contacto</li>
         -->


### PR DESCRIPTION
Quitar link a "Mapas de Ayuda" del footer. La sección ya no existe